### PR TITLE
Fix compilation of tests with generic SimInput types

### DIFF
--- a/src/tests/demo_input_struct.rs
+++ b/src/tests/demo_input_struct.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::input_trait::SimInput;
+use crate::input_trait::{SimInput, TestInputBytes};
 
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
 pub struct PlayerInput {
@@ -104,5 +104,11 @@ impl SimInput for PlayerInput {
     }
     fn from_bytes(bytes: Self::Bytes) -> Self {
         bytes.to_input()
+    }
+}
+
+impl TestInputBytes for PlayerInput {
+    fn new_test_simple(x: u32) -> Self::Bytes {
+        PlayerInputBinary::new_test_simple(x as u8)
     }
 }

--- a/src/tests/test_multiplayer_input_buffer.rs
+++ b/src/tests/test_multiplayer_input_buffer.rs
@@ -73,7 +73,7 @@ fn test_buffer_len_per_player() {
 #[test]
 fn test_receive_peer_input_slice() {
     let mut buffers = MultiplayerInputBuffers::<PlayerInput>::default();
-    let slice = PlayerInputSlice {
+    let slice = PlayerInputSlice::<PlayerInput> {
         start: 0,
         inputs: vec![
             PlayerInputBinary::new_test_simple(1),
@@ -102,7 +102,7 @@ fn test_host_append_default_inputs() {
 #[test]
 fn test_receive_finalized_input_slice() {
     let mut buffers = MultiplayerInputBuffers::<PlayerInput>::default();
-    let slice = PlayerInputSlice {
+    let slice = PlayerInputSlice::<PlayerInput> {
         start: 0,
         inputs: vec![
             PlayerInputBinary::new_test_simple(1),

--- a/src/tests/test_multiplayer_input_manager.rs
+++ b/src/tests/test_multiplayer_input_manager.rs
@@ -1,9 +1,16 @@
 
-use super::*;
+use super::demo_input_struct::{PlayerInput, PlayerInputBinary};
+use crate::{
+    input_messages::{HostFinalizedSlice, MsgPayload},
+    multiplayer_input_manager::MultiplayerInputManager,
+    multiplayer_input_manager_guest::GuestInputMgr,
+    util_types::PlayerInputSlice,
+};
 
 #[test]
 fn test_new_manager() {
-    let manager = MultiplayerInputManager::<GuestInputMgr>::new(4, 1.into(), 60);
+    let manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(4, 1.into(), 60);
     assert_eq!(manager.own_player_num, PlayerNum(1));
     assert_eq!(manager.inner.host_tick, i32::MIN);
     assert!(manager.inner.rtt_ms_to_host.is_none());
@@ -13,7 +20,8 @@ fn test_new_manager() {
 
 #[test]
 fn test_rtt_observation() {
-    let mut manager = MultiplayerInputManager::<GuestInputMgr>::new(4, 1.into(), 60);
+    let mut manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(4, 1.into(), 60);
     manager.observe_rtt_ms_to_host(100.0);
     assert!((manager.get_rtt_ms_to_host() - 100.0).abs() < f32::EPSILON);
 
@@ -25,7 +33,8 @@ fn test_rtt_observation() {
 
 #[test]
 fn test_num_inputs_needed() {
-    let mut manager = MultiplayerInputManager::<GuestInputMgr>::new(4, 1.into(), 2);
+    let mut manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(4, 1.into(), 2);
     // Without RTT or host tick, should return 1
     assert_eq!(manager.num_inputs_needed(), 1);
 
@@ -54,7 +63,8 @@ fn test_num_inputs_needed() {
 fn test_snapshottable_sim_tick() {
     let own_id = 1;
 
-    let mut manager = MultiplayerInputManager::<GuestInputMgr>::new(2, own_id.into(), 60);
+    let mut manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(2, own_id.into(), 60);
     // Add some inputs
     for _ in 0..5 {
         manager.add_own_input(PlayerInput::default());
@@ -63,7 +73,7 @@ fn test_snapshottable_sim_tick() {
     assert_eq!(manager.get_snapshottable_sim_tick(), 0);
 
     // rx a finalized input slice for self
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(own_id.into(), 0, 0, 5));
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(own_id.into(), 0, 0, 5));
     manager.rx_final_peer_input_slice_from_host(msg);
 
     // peer 1 has 1 finalized input, across all peers we still have 0
@@ -73,7 +83,7 @@ fn test_snapshottable_sim_tick() {
     // but with a lower max tick
     let host_id = 0;
     let inputs_to_add = 3;
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(
         host_id.into(),
         0,
         0,
@@ -86,7 +96,7 @@ fn test_snapshottable_sim_tick() {
 
     // rx a finalized input slice for other player
     // that would leave a gap in the input buffer
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(
         host_id.into(),
         0,
         inputs_to_add + 1,
@@ -101,7 +111,7 @@ fn test_snapshottable_sim_tick() {
 
     // rx a finalized input slice for other player
     // that does not leave a gap in the input buffer
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(
         host_id.into(),
         0,
         inputs_to_add,
@@ -118,7 +128,8 @@ fn test_snapshottable_sim_tick() {
 #[test]
 pub fn test_get_msg_own_input_slice() {
     let own_id = 1;
-    let mut manager = MultiplayerInputManager::<GuestInputMgr>::new(4, own_id.into(), 60);
+    let mut manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(4, own_id.into(), 60);
     // Add some inputs
     for _ in 0..10 {
         manager.add_own_input(PlayerInput::default());
@@ -133,7 +144,7 @@ pub fn test_get_msg_own_input_slice() {
     }
 
     // now rx a finalized input slice for self with only 3 inputs
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(own_id.into(), 0, 0, 3));
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(own_id.into(), 0, 0, 3));
     manager.rx_final_peer_input_slice_from_host(msg);
     assert_eq!(manager.num_final_inputs_seen_by_host(), 3);
 
@@ -150,7 +161,8 @@ pub fn test_get_msg_own_input_slice() {
 #[test]
 pub fn test_get_msg_ack_finalization() {
     let own_id = 1;
-    let mut manager = MultiplayerInputManager::<GuestInputMgr>::new(4, own_id.into(), 60);
+    let mut manager =
+        MultiplayerInputManager::<PlayerInput, GuestInputMgr>::new(4, own_id.into(), 60);
     // Add some inputs
     for _ in 0..10 {
         manager.add_own_input(PlayerInput::default());
@@ -165,7 +177,7 @@ pub fn test_get_msg_ack_finalization() {
     }
 
     // now rx a finalized input slice for self with only 3 inputs
-    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(own_id.into(), 0, 0, 3));
+    let msg = MsgPayload::HostFinalizedSlice(HostFinalizedSlice::<PlayerInput>::new_test(own_id.into(), 0, 0, 3));
     manager.rx_final_peer_input_slice_from_host(msg);
     assert_eq!(manager.num_final_inputs_seen_by_host(), 3);
 
@@ -179,8 +191,9 @@ pub fn test_get_msg_ack_finalization() {
 
     // now rx a finalized input slice for another player
     let other_id = 2;
-    let msg =
-        MsgPayload::HostFinalizedSlice(HostFinalizedSlice::new_test(other_id.into(), 0, 0, 5));
+    let msg = MsgPayload::HostFinalizedSlice(
+        HostFinalizedSlice::<PlayerInput>::new_test(other_id.into(), 0, 0, 5),
+    );
     manager.rx_final_peer_input_slice_from_host(msg);
 
     let msg_finalize = manager.get_msg_ack_finalization();

--- a/src/tests/test_player_input_buffer.rs
+++ b/src/tests/test_player_input_buffer.rs
@@ -1,10 +1,18 @@
+use crate::{
+    input_buffer::PlayerInputBuffer,
+    tests::demo_input_struct::{PlayerInput, PlayerInputBinary},
+    util_types::PlayerInputSlice,
+};
+
+type T = PlayerInput;
+
 #[test]
 fn test_input_buffer_basics() {
-    let mut buffer = PlayerInputBuffer::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
     assert_eq!(buffer.num_inputs_collected(), 0);
     assert_eq!(buffer.finalized_inputs, 0);
 
-    let input = T::default();
+    let input = PlayerInputBinary::default();
     buffer.append_input(input);
     assert_eq!(buffer.num_inputs_collected(), 1);
     assert_eq!(buffer.finalized_inputs, 0);
@@ -12,8 +20,8 @@ fn test_input_buffer_basics() {
 
 #[test]
 fn test_host_append_finalized() {
-    let mut buffer = PlayerInputBuffer::default();
-    let input = T::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
+    let input = PlayerInputBinary::default();
 
     buffer.host_append_finalized(input);
     assert_eq!(buffer.finalized_inputs, 1);
@@ -22,7 +30,7 @@ fn test_host_append_finalized() {
 
 #[test]
 fn test_get_input_or_prediction() {
-    let mut buffer = PlayerInputBuffer::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
     // default if nothing yet in buffer,
     // for any combination of tick and max_ticks_to_predict_locf
     assert_eq!(buffer.get_input_or_prediction(0, 0), T::default());
@@ -45,33 +53,33 @@ fn test_get_input_or_prediction() {
 
 #[test]
 fn test_receive_finalized_input_slice() {
-    let mut buffer = PlayerInputBuffer::default();
-    let slice = PlayerInputSlice::new_test(0, 5);
+    let mut buffer = PlayerInputBuffer::<T>::default();
+    let slice = PlayerInputSlice::<T>::new_test(0, 5);
 
     buffer.receive_finalized_input_slice(slice);
     assert_eq!(buffer.finalized_inputs, 5);
     assert_eq!(buffer.num_inputs_collected(), 5);
 
     // Test slice with gap (should be ignored)
-    let slice_with_gap = PlayerInputSlice::new_test(6, 5);
+    let slice_with_gap = PlayerInputSlice::<T>::new_test(6, 5);
     buffer.receive_finalized_input_slice(slice_with_gap);
     assert_eq!(buffer.finalized_inputs, 5);
 }
 
 #[test]
 fn test_receive_peer_input_slice() {
-    let mut buffer = PlayerInputBuffer::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
 
     // zero finalized inputs so far
     assert_eq!(buffer.finalized_inputs, 0);
 
-    buffer.receive_finalized_input_slice(PlayerInputSlice::new_test(0, 2));
+    buffer.receive_finalized_input_slice(PlayerInputSlice::<T>::new_test(0, 2));
 
     // now we have 2 finalized inputs
     assert_eq!(buffer.finalized_inputs, 2);
 
     // rx a slice of inputs that have not been finalized
-    let slice = PlayerInputSlice::new_test(0, 5);
+    let slice = PlayerInputSlice::<T>::new_test(0, 5);
 
     // the buffer should now have 5 inputs, but still only 2 finalized
     buffer.receive_peer_input_slice(slice);
@@ -79,7 +87,7 @@ fn test_receive_peer_input_slice() {
     assert_eq!(buffer.finalized_inputs, 2);
 
     // rx 4 more finalized inputs
-    buffer.receive_finalized_input_slice(PlayerInputSlice::new_test(2, 4));
+    buffer.receive_finalized_input_slice(PlayerInputSlice::<T>::new_test(2, 4));
     // now we have 6 inputs, and all of them are finalized
     assert_eq!(buffer.num_inputs_collected(), 6);
     assert_eq!(buffer.finalized_inputs, 6);
@@ -87,29 +95,29 @@ fn test_receive_peer_input_slice() {
 
 #[test]
 fn test_rx_out_of_order_final_slices() {
-    let mut buffer = PlayerInputBuffer::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
 
     // add 5 default inputs
-    buffer.receive_finalized_input_slice(PlayerInputSlice {
+    buffer.receive_finalized_input_slice(PlayerInputSlice::<T> {
         start: 0,
         inputs: vec![
-            T::default(),
-            T::default(),
-            T::default(),
-            T::default(),
-            T::default(),
+            PlayerInputBinary::default(),
+            PlayerInputBinary::default(),
+            PlayerInputBinary::default(),
+            PlayerInputBinary::default(),
+            PlayerInputBinary::default(),
         ],
     });
 
     // now rx a finalized slice that starts at 0
-    buffer.receive_finalized_input_slice(PlayerInputSlice {
+    buffer.receive_finalized_input_slice(PlayerInputSlice::<T> {
         start: 0,
         inputs: vec![
-            T::new_test_simple(10),
-            T::new_test_simple(20),
-            T::new_test_simple(30),
-            T::new_test_simple(40),
-            T::new_test_simple(50),
+            PlayerInputBinary::new_test_simple(10),
+            PlayerInputBinary::new_test_simple(20),
+            PlayerInputBinary::new_test_simple(30),
+            PlayerInputBinary::new_test_simple(40),
+            PlayerInputBinary::new_test_simple(50),
         ],
     });
 
@@ -123,7 +131,7 @@ fn test_rx_out_of_order_final_slices() {
 
 #[test]
 fn test_host_finalize_default_thru_tick() {
-    let mut buffer = PlayerInputBuffer::default();
+    let mut buffer = PlayerInputBuffer::<T>::default();
     buffer.host_append_final_default_inputs_to_target(4);
 
     assert_eq!(buffer.num_inputs_collected(), 5);
@@ -135,8 +143,8 @@ fn test_host_finalize_default_thru_tick() {
 
 #[test]
 fn test_host_finalize_default_thru_tick_wont_overwrite() {
-    let mut buffer = PlayerInputBuffer::default();
-    buffer.receive_finalized_input_slice(PlayerInputSlice::new_test(0, 5));
+    let mut buffer = PlayerInputBuffer::<T>::default();
+    buffer.receive_finalized_input_slice(PlayerInputSlice::<T>::new_test(0, 5));
     for i in 0..5 {
         assert_eq!(buffer.inputs[i], T::new_test_simple(i as u8));
     }


### PR DESCRIPTION
## Summary
- update demo input to implement `TestInputBytes`
- specify `PlayerInput` generics in test helpers
- update all tests with concrete generic parameters and proper byte types

## Testing
- `cargo test --no-run` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_6840f775faac8323921873b3c8456a6d