### PR TITLE
Add README and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Temporal Input Buffer
+
+Temporal Input Buffer is a small Rust library for synchronizing player inputs in
+multiplayer games.  It provides data structures for collecting per-player input
+states, finalizing them on a host, and sharing finalized slices with peers.
+
+The crate is written with deterministic lockstep style games in mind.  Each
+input implements the `SimInput` trait which allows conversion to and from a
+fixed-size byte representation.  Input buffers keep track of finalized and
+non-finalized ticks and can predict missing inputs using a simple
+last-observation carried forward strategy.
+
+Key modules:
+
+- `input_trait` – defines the `SimInput` trait used by inputs.
+- `input_buffer` – handles a single player's input history.
+- `multiplayer_input_buffer` – collections of buffers for all players.
+- `multiplayer_input_manager` – common logic shared by host and guest managers.
+- `multiplayer_input_manager_host` / `multiplayer_input_manager_guest` – manage
+  communication of input slices and acknowledgements between peers.
+- `input_messages` – serializable message types used over the network.
+- `button_state` and `ewma` – helper utilities used by the managers.
+
+The repository also contains extensive unit tests demonstrating usage with a
+simple `PlayerInput` structure.
+
+To run the tests:
+
+```bash
+cargo test
+```
+
+This project requires the nightly Rust toolchain because it uses the
+`duration_millis_float` feature for timing utilities.  The required toolchain is
+specified in `rust-toolchain.toml` and will be downloaded automatically by
+`rustup` when building.

--- a/src/input_buffer.rs
+++ b/src/input_buffer.rs
@@ -4,12 +4,12 @@ use serde::{Deserialize, Serialize};
 
 /// The status of the inputs for a given tick.
 pub enum InputStatus {
-    /// Recieved from a peer and finalized by the host.
+    /// Received from a peer and finalized by the host.
     Finalized,
-    /// Recieved from a peer, but not yet finalized.
+    /// Received from a peer, but not yet finalized.
     NonFinal,
-    /// Not yet recieved from a peer.
-    NotRecieved,
+    /// Not yet received from a peer.
+    NotReceived,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -114,7 +114,7 @@ where
         } else if input_num < self.inputs.len() as u32 {
             InputStatus::NonFinal
         } else {
-            InputStatus::NotRecieved
+            InputStatus::NotReceived
         }
     }
 

--- a/src/multiplayer_input_manager_host.rs
+++ b/src/multiplayer_input_manager_host.rs
@@ -33,7 +33,7 @@ impl PongSendTimes {
     }
 }
 
-pub struct HostInpugMgr {
+pub struct HostInputMgr {
     /// tracks the number of finalized input ticks
     /// that each GUEST has acked for each other peer,
     /// including the host.
@@ -58,7 +58,7 @@ pub struct HostInpugMgr {
     disconnected_players: Vec<PlayerNum>,
 }
 
-impl HostInpugMgr {
+impl HostInputMgr {
     fn new(max_guest_ticks_behind: u32) -> Self {
         Self {
             guests_finalized_observations: HashMap::default(),
@@ -70,7 +70,7 @@ impl HostInpugMgr {
     }
 }
 
-impl<T: SimInput> MultiplayerInputManager<T, HostInpugMgr> {
+impl<T: SimInput> MultiplayerInputManager<T, HostInputMgr> {
     // CONSTRUCTORS ///////////////////////////////////////////
     pub fn new(
         num_players: u8,
@@ -79,7 +79,7 @@ impl<T: SimInput> MultiplayerInputManager<T, HostInpugMgr> {
     ) -> Self {
         Self {
             buffers: MultiplayerInputBuffers::new(num_players, max_ticks_to_predict_locf),
-            inner: HostInpugMgr::new(max_guest_ticks_behind),
+            inner: HostInputMgr::new(max_guest_ticks_behind),
             own_player_num: HOST_PLAYER_NUM,
         }
     }
@@ -95,7 +95,7 @@ impl<T: SimInput> MultiplayerInputManager<T, HostInpugMgr> {
     /// Finalize a slice of inputs to the input buffer for
     /// the player with the given player_num.
     pub fn rx_guest_input_slice(&mut self, player_num: PlayerNum, msg: MsgPayload<T>) {
-        self.add_input_obervations_if_needed(player_num.into());
+        self.add_input_observations_if_needed(player_num.into());
         if let Ok(input_slice) = msg.try_into() {
             self.buffers
                 .receive_finalized_input_slice_for_player(input_slice, player_num);
@@ -106,7 +106,7 @@ impl<T: SimInput> MultiplayerInputManager<T, HostInpugMgr> {
 
     /// The host input manager should add input observations for each guest
     /// as soon it becomes aware of them.
-    fn add_input_obervations_if_needed(&mut self, player_num: PlayerNum) {
+    fn add_input_observations_if_needed(&mut self, player_num: PlayerNum) {
         self.inner
             .guests_finalized_observations
             .entry(player_num)

--- a/src/peerwise_finalized_input.rs
+++ b/src/peerwise_finalized_input.rs
@@ -57,7 +57,7 @@ impl PeerwiseFinalizedInputsSeen {
         ack
     }
 
-    pub fn ealiest_input_finalized_by_all(&self) -> u32 {
+    pub fn earliest_input_finalized_by_all(&self) -> u32 {
         self.0.values().copied().min().unwrap_or(0)
     }
 }

--- a/src/tests/test_multiplayer_input_manager_host.rs
+++ b/src/tests/test_multiplayer_input_manager_host.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     input_messages::{HostFinalizedSlice, MsgPayload},
     multiplayer_input_manager::MultiplayerInputManager,
-    multiplayer_input_manager_host::{HOST_PLAYER_NUM, HostInpugMgr},
+    multiplayer_input_manager_host::{HOST_PLAYER_NUM, HostInputMgr},
     peerwise_finalized_input::PeerwiseFinalizedInputsSeen,
     tests::demo_input_struct::PlayerInput,
     util_types::{PlayerInputSlice, PlayerNum},
@@ -14,7 +14,7 @@ const MAX_TICKS_PREDICT_LOCF: u32 = 5;
 #[test]
 fn test_new_manager() {
     let manager =
-        MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
+        MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
     assert_eq!(manager.inner.max_guest_ticks_behind, 5);
     assert!(manager.inner.guests_finalized_observations.is_empty());
 }
@@ -22,7 +22,7 @@ fn test_new_manager() {
 #[test]
 fn test_snapshottable_sim_tick() {
     let mut manager =
-        MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(2, 5, MAX_TICKS_PREDICT_LOCF);
+        MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(2, 5, MAX_TICKS_PREDICT_LOCF);
 
     // Add some inputs for host
     for _ in 0..5 {
@@ -47,7 +47,7 @@ fn test_snapshottable_sim_tick() {
 #[test]
 fn test_get_finalization_start_for_peer() {
     let mut manager =
-        MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
+        MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
 
     // Add some inputs for host
     for _ in 0..5 {
@@ -96,7 +96,7 @@ fn test_get_finalization_start_for_peer() {
 #[test]
 fn test_get_finalization_start_for_peer_2() {
     let mut manager =
-        MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
+        MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(4, 5, MAX_TICKS_PREDICT_LOCF);
 
     // Add some inputs for host
     for _ in 0..5 {
@@ -182,7 +182,7 @@ fn test_get_finalization_start_for_peer_2() {
 #[test]
 fn test_get_msg_catch_up_with_no_acks() {
     let max_ticks_behind = 5;
-    let mut manager = MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(
+    let mut manager = MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(
         4,
         max_ticks_behind,
         MAX_TICKS_PREDICT_LOCF,
@@ -242,7 +242,7 @@ fn test_get_msg_catch_up_with_no_acks() {
 #[test]
 fn test_get_msg_catch_up_with_guest_acks() {
     let max_ticks_behind = 5;
-    let mut manager = MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(
+    let mut manager = MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(
         4,
         max_ticks_behind,
         MAX_TICKS_PREDICT_LOCF,
@@ -306,7 +306,7 @@ fn test_get_msg_catch_up_with_guest_acks() {
 #[test]
 pub fn test_get_msg_host_finalized_slice_no_ack() {
     let max_ticks_behind = 5;
-    let mut manager = MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(
+    let mut manager = MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(
         4,
         max_ticks_behind,
         MAX_TICKS_PREDICT_LOCF,
@@ -363,7 +363,7 @@ pub fn test_get_msg_host_finalized_slice_no_ack() {
 
 pub fn test_get_msg_host_finalized_slice_1_ack() {
     let max_ticks_behind = 5;
-    let mut manager = MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(
+    let mut manager = MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(
         4,
         max_ticks_behind,
         MAX_TICKS_PREDICT_LOCF,
@@ -433,7 +433,7 @@ pub fn test_get_msg_host_finalized_slice_1_ack() {
 
 pub fn test_get_msg_host_finalized_slice_2_acks() {
     let max_ticks_behind = 5;
-    let mut manager = MultiplayerInputManager::<PlayerInput, HostInpugMgr>::new(
+    let mut manager = MultiplayerInputManager::<PlayerInput, HostInputMgr>::new(
         4,
         max_ticks_behind,
         MAX_TICKS_PREDICT_LOCF,


### PR DESCRIPTION
## Summary
- document crate in a new README
- correct misspellings (NotReceived enum, HostInputMgr struct, earliest_input_finalized_by_all)
- update tests to new names

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68410213c1a48323b1029f3e3c6e2661