### PR TITLE
Add coverage for multiplayer input helpers

### DIFF
--- a/src/input_buffer.rs
+++ b/src/input_buffer.rs
@@ -109,7 +109,7 @@ where
     }
 
     pub fn get_input_status(&self, input_num: u32) -> InputStatus {
-        if input_num <= self.finalized_inputs {
+        if input_num < self.finalized_inputs {
             InputStatus::Finalized
         } else if input_num < self.inputs.len() as u32 {
             InputStatus::NonFinal


### PR DESCRIPTION
## Summary
- expand multiplayer input buffer tests
- fix `InputStatus` check to use `<` rather than `<=`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68410f547d608323a750ab832d1f1b1f