### PR TITLE
Add MsgPayload serialization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,40 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "serde",
+ "test-case",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 
 serde = { version = "1.0.214", features = ["derive"] }
 bincode = "1.3.3"
+
+[dev-dependencies]
+test-case = "3.3.1"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,3 +3,4 @@ pub mod test_multiplayer_input_buffer;
 pub mod test_multiplayer_input_manager;
 pub mod test_multiplayer_input_manager_host;
 pub mod test_player_input_buffer;
+pub mod test_input_messages;

--- a/src/tests/test_input_messages.rs
+++ b/src/tests/test_input_messages.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use test_case::test_case;
+
+use crate::{
+    input_messages::{HostFinalizedSlice, MsgPayload, PreSimSync},
+    peerwise_finalized_input::PeerwiseFinalizedInputsSeen,
+    tests::demo_input_struct::PlayerInput,
+    util_types::{PlayerInputSlice, PlayerNum},
+};
+
+
+#[test_case(MsgPayload::<PlayerInput>::Empty; "empty")]
+#[test_case(MsgPayload::<PlayerInput>::Invalid; "invalid")]
+#[test_case(MsgPayload::<PlayerInput>::AckFinalization(
+    PeerwiseFinalizedInputsSeen::new(HashMap::from([(PlayerNum(1), 3u32)]))
+); "ack finalization")]
+#[test_case(MsgPayload::<PlayerInput>::HostFinalizedSlice(
+    HostFinalizedSlice::<PlayerInput>::new_test(PlayerNum(2), 5, 0, 2)
+); "host finalized slice")]
+#[test_case(MsgPayload::<PlayerInput>::PeerInputs(
+    PlayerInputSlice::<PlayerInput>::new_test(10, 3)
+); "peer inputs")]
+#[test_case(MsgPayload::<PlayerInput>::PreSimSync(PreSimSync {
+    host_tick_countdown: 4,
+    peers: vec![0, 1, 2],
+}); "pre sim sync")]
+#[test_case(MsgPayload::<PlayerInput>::GuestPing(42); "guest ping")]
+#[test_case(MsgPayload::<PlayerInput>::HostPong(43); "host pong")]
+#[test_case(MsgPayload::<PlayerInput>::GuestPongPong(44); "guest pong pong")]
+fn test_msg_payload_round_trip(payload: MsgPayload<PlayerInput>) {
+    // Ensure every MsgPayload variant survives a to_bytes/from_bytes round trip.
+    let bytes = payload.to_bytes();
+    let decoded = MsgPayload::<PlayerInput>::from_bytes(&bytes).unwrap();
+
+    match (&payload, &decoded) {
+        (MsgPayload::Empty, MsgPayload::Empty) => {}
+        (MsgPayload::Invalid, MsgPayload::Invalid) => {}
+        (MsgPayload::AckFinalization(a1), MsgPayload::AckFinalization(a2)) => {
+            assert_eq!(a1.inner(), a2.inner());
+        }
+        (MsgPayload::HostFinalizedSlice(s1), MsgPayload::HostFinalizedSlice(s2)) => {
+            assert_eq!(s1.player_num, s2.player_num);
+            assert_eq!(s1.host_tick, s2.host_tick);
+            assert_eq!(s1.inputs.start, s2.inputs.start);
+            assert_eq!(s1.inputs.inputs, s2.inputs.inputs);
+        }
+        (MsgPayload::PeerInputs(s1), MsgPayload::PeerInputs(s2)) => {
+            assert_eq!(s1.start, s2.start);
+            assert_eq!(s1.inputs, s2.inputs);
+        }
+        (MsgPayload::PreSimSync(ps1), MsgPayload::PreSimSync(ps2)) => {
+            assert_eq!(ps1.host_tick_countdown, ps2.host_tick_countdown);
+            assert_eq!(ps1.peers, ps2.peers);
+        }
+        (MsgPayload::GuestPing(p1), MsgPayload::GuestPing(p2)) => assert_eq!(p1, p2),
+        (MsgPayload::HostPong(p1), MsgPayload::HostPong(p2)) => assert_eq!(p1, p2),
+        (MsgPayload::GuestPongPong(p1), MsgPayload::GuestPongPong(p2)) => assert_eq!(p1, p2),
+        _ => panic!("Variant mismatch after round trip"),
+    }
+
+    assert_eq!(decoded.to_bytes(), bytes);
+}
+
+#[test]
+fn test_msg_payload_unknown_variant() {
+    // Deserializing an unknown variant number should produce an error
+    let bytes = vec![255u8];
+    assert!(MsgPayload::<PlayerInput>::from_bytes(&bytes).is_err());
+}


### PR DESCRIPTION
## Summary
- refactor MsgPayload round trip tests to use `test-case`
- add `test-case` dev dependency

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684134ea6a10832386949f08667fcd39