### PR TITLE
Add PlayerNum conversion tests

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,3 +3,4 @@ pub mod test_multiplayer_input_buffer;
 pub mod test_multiplayer_input_manager;
 pub mod test_multiplayer_input_manager_host;
 pub mod test_player_input_buffer;
+pub mod test_playernum;

--- a/src/tests/test_playernum.rs
+++ b/src/tests/test_playernum.rs
@@ -1,0 +1,45 @@
+use crate::util_types::PlayerNum;
+use std::convert::TryFrom;
+
+#[test]
+fn test_from_u8() {
+    let num: PlayerNum = 5u8.into();
+    assert_eq!(num, PlayerNum(5));
+}
+
+#[test]
+fn test_try_from_u32() {
+    let num = PlayerNum::try_from(42u32).unwrap();
+    assert_eq!(num, PlayerNum(42));
+}
+
+#[test]
+fn test_try_from_u32_out_of_range() {
+    assert!(PlayerNum::try_from(300u32).is_err());
+}
+
+#[test]
+fn test_try_from_usize() {
+    let num = PlayerNum::try_from(100usize).unwrap();
+    assert_eq!(num, PlayerNum(100));
+}
+
+#[test]
+fn test_try_from_usize_out_of_range() {
+    assert!(PlayerNum::try_from(300usize).is_err());
+}
+
+#[test]
+fn test_into_values() {
+    let num = PlayerNum(7);
+    let val_u8: u8 = num.into();
+    assert_eq!(val_u8, 7);
+
+    let num = PlayerNum(8);
+    let val_u32: u32 = num.into();
+    assert_eq!(val_u32, 8);
+
+    let num = PlayerNum(9);
+    let val_string: String = num.into();
+    assert_eq!(val_string, "9");
+}


### PR DESCRIPTION
## Summary
- add new tests for PlayerNum conversions
- register the new tests in the test module list

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68410f5247b48323ae33e91c7ea53c72