### PR TITLE
Add coverage reporting job to Rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Install Rust toolchain (stable) via the rust-lang setup action
+      # Install Rust toolchain (nightly) via the rust-lang setup action
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
@@ -25,4 +25,36 @@ jobs:
         run: cargo build
 
       - name: Test
-        run: cargo test 
+        run: cargo test
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Collect coverage
+        run: >-
+          cargo llvm-cov --workspace --all-targets --lcov
+          --output-path target/llvm-cov/lcov.info --html
+
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: target/llvm-cov/html/
+
+      - name: Upload coverage LCOV report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: target/llvm-cov/lcov.info

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Collect coverage
         run: >-
-          cargo llvm-cov --workspace --all-targets --lcov
-          --output-path target/llvm-cov/lcov.info --html
+          cargo llvm-cov --branch --html
+          --output-path target/llvm-cov/lcov.info
 
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add a dedicated coverage job that installs cargo-llvm-cov and runs coverage collection
- upload the generated HTML and LCOV reports as workflow artifacts for download

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f1d57cf8888323b0c26728c9664a07