### PR TITLE
Add Codecov upload and badge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,3 +68,9 @@ jobs:
         with:
           name: coverage-lcov
           path: target/llvm-cov/lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: target/llvm-cov/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Temporal Input Buffer
 
+[![Coverage](https://codecov.io/gh/temporal-input-buffer/temporal_input_buffer/branch/main/graph/badge.svg)](https://codecov.io/gh/temporal-input-buffer/temporal_input_buffer)
+
 Temporal Input Buffer is a small Rust library for synchronizing player inputs in
 multiplayer games.  It provides data structures for collecting per-player input
 states, finalizing them on a host, and sharing finalized slices with peers.


### PR DESCRIPTION
## Summary
- update the coverage workflow to publish lcov output to Codecov in addition to artifacts
- add a Codecov coverage badge to the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2cb793a388323b069468d88b522e7